### PR TITLE
Fix typo in project state enum

### DIFF
--- a/truongdev/src/main/java/com/dev/truongdev/utils/AppConstants.java
+++ b/truongdev/src/main/java/com/dev/truongdev/utils/AppConstants.java
@@ -33,7 +33,7 @@ public class AppConstants {
 
   @Getter
   public enum State {
-     PENDING, REJECTED, IN_PROGRESS, COMPLETE, OVERDUE, CANCELEDs
+     PENDING, REJECTED, IN_PROGRESS, COMPLETE, OVERDUE, CANCELED
   }
 
   public static String getStatusName(Integer status) {


### PR DESCRIPTION
## Summary
- fix typo in `AppConstants` enum to use `CANCELED`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `npm test --silent` *(no output)*

------
https://chatgpt.com/codex/tasks/task_b_684e87b4ed4483309cc660ce9ac2f414