### PR TITLE
Refactor dashload DTOs to dashboard

### DIFF
--- a/truongdev/src/main/java/com/dev/truongdev/api/DepartmentAPI.java
+++ b/truongdev/src/main/java/com/dev/truongdev/api/DepartmentAPI.java
@@ -1,6 +1,6 @@
 package com.dev.truongdev.api;
 
-import com.dev.truongdev.dto.dashload.department.DepartmentStatsDTO;
+import com.dev.truongdev.dto.dashboard.department.DepartmentStatsDTO;
 import com.dev.truongdev.entity.Department;
 import com.dev.truongdev.payload.filter.DepartmentFilter;
 import com.dev.truongdev.service.IDepartmentService;

--- a/truongdev/src/main/java/com/dev/truongdev/api/ProjectAPI.java
+++ b/truongdev/src/main/java/com/dev/truongdev/api/ProjectAPI.java
@@ -1,7 +1,7 @@
 package com.dev.truongdev.api;
 
-import com.dev.truongdev.dto.dashload.department.DepartmentStatsDTO;
-import com.dev.truongdev.dto.dashload.project.ProjectStatsDTO;
+import com.dev.truongdev.dto.dashboard.department.DepartmentStatsDTO;
+import com.dev.truongdev.dto.dashboard.project.ProjectStatsDTO;
 import com.dev.truongdev.entity.Project;
 import com.dev.truongdev.entity.ProjectHistory;
 import com.dev.truongdev.dto.ProjectDTO;

--- a/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/DepartmentStatsDTO.java
+++ b/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/DepartmentStatsDTO.java
@@ -1,4 +1,4 @@
-package com.dev.truongdev.dto.dashload.department;
+package com.dev.truongdev.dto.dashboard.department;
 
 import java.util.List;
 import lombok.AccessLevel;

--- a/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/ProjectProgressDTO.java
+++ b/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/ProjectProgressDTO.java
@@ -1,4 +1,4 @@
-package com.dev.truongdev.dto.dashload.department;
+package com.dev.truongdev.dto.dashboard.department;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/UserPerformanceDataDTO.java
+++ b/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/UserPerformanceDataDTO.java
@@ -1,4 +1,4 @@
-package com.dev.truongdev.dto.dashload.department;
+package com.dev.truongdev.dto.dashboard.department;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/UserStatsDTO.java
+++ b/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/department/UserStatsDTO.java
@@ -1,6 +1,6 @@
-package com.dev.truongdev.dto.dashload.department;
+package com.dev.truongdev.dto.dashboard.department;
 
-import com.dev.truongdev.dto.dashload.department.UserPerformanceDataDTO;
+import com.dev.truongdev.dto.dashboard.department.UserPerformanceDataDTO;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/project/ProjectStatsDTO.java
+++ b/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/project/ProjectStatsDTO.java
@@ -1,4 +1,4 @@
-package com.dev.truongdev.dto.dashload.project;
+package com.dev.truongdev.dto.dashboard.project;
 
 import java.util.List;
 import lombok.AccessLevel;

--- a/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/project/UserProjectStatsDTO.java
+++ b/truongdev/src/main/java/com/dev/truongdev/dto/dashboard/project/UserProjectStatsDTO.java
@@ -1,4 +1,4 @@
-package com.dev.truongdev.dto.dashload.project;
+package com.dev.truongdev.dto.dashboard.project;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/truongdev/src/main/java/com/dev/truongdev/service/IDepartmentService.java
+++ b/truongdev/src/main/java/com/dev/truongdev/service/IDepartmentService.java
@@ -1,6 +1,6 @@
 package com.dev.truongdev.service;
 
-import com.dev.truongdev.dto.dashload.department.DepartmentStatsDTO;
+import com.dev.truongdev.dto.dashboard.department.DepartmentStatsDTO;
 import com.dev.truongdev.entity.Department;
 import com.dev.truongdev.payload.filter.DepartmentFilter;
 import com.dev.truongdev.xdevbase.service.IXDevBaseService;

--- a/truongdev/src/main/java/com/dev/truongdev/service/IProjectService.java
+++ b/truongdev/src/main/java/com/dev/truongdev/service/IProjectService.java
@@ -1,8 +1,8 @@
 package com.dev.truongdev.service;
 
 import com.dev.truongdev.dto.ProjectDTO;
-import com.dev.truongdev.dto.dashload.department.DepartmentStatsDTO;
-import com.dev.truongdev.dto.dashload.project.ProjectStatsDTO;
+import com.dev.truongdev.dto.dashboard.department.DepartmentStatsDTO;
+import com.dev.truongdev.dto.dashboard.project.ProjectStatsDTO;
 import com.dev.truongdev.entity.Project;
 import com.dev.truongdev.payload.filter.ProjectFilter;
 import com.dev.truongdev.xdevbase.service.IXDevBaseService;

--- a/truongdev/src/main/java/com/dev/truongdev/service/impl/DepartmentServiceImpl.java
+++ b/truongdev/src/main/java/com/dev/truongdev/service/impl/DepartmentServiceImpl.java
@@ -1,9 +1,9 @@
 package com.dev.truongdev.service.impl;
 
-import com.dev.truongdev.dto.dashload.department.DepartmentStatsDTO;
-import com.dev.truongdev.dto.dashload.department.ProjectProgressDTO;
-import com.dev.truongdev.dto.dashload.department.UserPerformanceDataDTO;
-import com.dev.truongdev.dto.dashload.department.UserStatsDTO;
+import com.dev.truongdev.dto.dashboard.department.DepartmentStatsDTO;
+import com.dev.truongdev.dto.dashboard.department.ProjectProgressDTO;
+import com.dev.truongdev.dto.dashboard.department.UserPerformanceDataDTO;
+import com.dev.truongdev.dto.dashboard.department.UserStatsDTO;
 import com.dev.truongdev.entity.Department;
 import com.dev.truongdev.entity.User;
 import com.dev.truongdev.payload.filter.DepartmentFilter;

--- a/truongdev/src/main/java/com/dev/truongdev/service/impl/ProjectServiceImpl.java
+++ b/truongdev/src/main/java/com/dev/truongdev/service/impl/ProjectServiceImpl.java
@@ -2,8 +2,8 @@ package com.dev.truongdev.service.impl;
 
 import com.dev.truongdev.dto.ProjectDTO;
 import com.dev.truongdev.dto.ProjectHistoryDTO;
-import com.dev.truongdev.dto.dashload.project.ProjectStatsDTO;
-import com.dev.truongdev.dto.dashload.project.UserProjectStatsDTO;
+import com.dev.truongdev.dto.dashboard.project.ProjectStatsDTO;
+import com.dev.truongdev.dto.dashboard.project.UserProjectStatsDTO;
 import com.dev.truongdev.entity.Project;
 import com.dev.truongdev.entity.ProjectHistory;
 import com.dev.truongdev.entity.Task;


### PR DESCRIPTION
## Summary
- rename `dto/dashload` to `dto/dashboard`
- update package names in DTO classes
- adjust imports in APIs and services to new `dashboard` package

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684e88a1d0e88330938d52b8e0247381